### PR TITLE
Don't upgrade all package when running idempotency checks with molecule

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,8 @@
   ansible.builtin.yum:
     name: "*"
     state: latest
+  tags:
+    - molecule-idempotence-notest
 
 - name: Ensure epel is installed
   become: true


### PR DESCRIPTION
- ignore the task to upgrade all packages when running idempotency checks with molecule
- this is to avoid failing the idempotency checks when this role is used as part of the [XNAT collection](https://github.com/UCL-MIRSG/ansible-collection-xnat)