### PR TITLE
make `EXTERNAL_STORAGE_DRIVE` lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you would like to run Ansible Molecule to test this role, the requirements ar
 
 `server_locale`: the sets the user's language, region, etc. This is set to "en_GB.UTF-8"
 
-`EXTERNAL_STORAGE_DRIVE`: path to mounted storage. By default this is undefined.
+`external_storage_drive`: path to mounted storage. By default this is undefined.
 
 ## Dependencies
 

--- a/tasks/check_mounts.yml
+++ b/tasks/check_mounts.yml
@@ -1,14 +1,14 @@
 ---
 - name: Ensure correct permissions are set for the mountpoint
   ansible.builtin.file:
-    path: "{{ EXTERNAL_STORAGE_DRIVE }}"
+    path: "{{ external_storage_drive }}"
     owner: root
     group: root
     state: directory
     mode: "0755"
 
-- name: "Check if storage is mounted: {{ EXTERNAL_STORAGE_DRIVE }}"
-  ansible.builtin.command: mountpoint {{ EXTERNAL_STORAGE_DRIVE }}
+- name: "Check if storage is mounted: {{ external_storage_drive }}"
+  ansible.builtin.command: mountpoint {{ external_storage_drive }}
   register: check_mountpoint
   failed_when: false
   changed_when: false
@@ -20,7 +20,7 @@
   when: "'is not a mountpoint' in check_mountpoint.stdout"
 
 - name: Check that storage has been mounted correctly if it was previously not mounted
-  ansible.builtin.command: mountpoint {{ EXTERNAL_STORAGE_DRIVE }}
+  ansible.builtin.command: mountpoint {{ external_storage_drive }}
   when: "'is not a mountpoint' in check_mountpoint.stdout"
   register: check_mountpoint_again
   failed_when: "'is not a mountpoint' in check_mountpoint_again.stdout"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Check mounts are available"
   tags: restart
   ansible.builtin.include_tasks: check_mounts.yml
-  when: EXTERNAL_STORAGE_DRIVE is defined
+  when: external_storage_drive is defined
 
 - name: "Set up for specific distribution"
   ansible.builtin.include_tasks: "{{ ansible_distribution }}.yml"


### PR DESCRIPTION
Make Ansible lint happy by renaming `EXTERNAL_STORAGE_DRIVE` to `external_storage_drive`